### PR TITLE
add new syntax for Coderunner 2.x to the Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ The script runs as an OSX app, so you cannot load iOS-specific frameworks. Howev
 
 5. A new file will open. Replace its contents with the following line. The path is the local path to the `motion-coderunner.rb` file in your Mac.
 
-  ruby "/Users/mark/src/motion-coderunner/motion-coderunner.rb" "$@"
+```bash
+# Coderunner version 1.x
+ruby "/Users/mark/src/motion-coderunner/motion-coderunner.rb" "$@"
+  
+# Coderunner version 2.x
+ruby "/Users/mark/src/motion-coderunner/motion-coderunner.rb" "$CR_FILENAME" "$CR_ENCODING" "$@" "$CR_TMPDIR"
+```
 
 6. Add `$compiler` into "Run Command:".
 


### PR DESCRIPTION
Because of new Mac App Store restrictions, CodeRunner 2 is currently only available outside of the Mac App Store, this can found under
[Coderunner 2](https://coderunnerapp.com). However with this new version, there is a new Syntax for the compiler file.
I just added this to the readme file.