### PR TITLE
Fixed typographical error, changed agaisnt to against in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ The script runs as an OSX app, so you cannot load iOS-specific frameworks. Howev
 
 # Extra frameworks
 
-By default, the script will link agaisnt a set of default frameworks. However, you can click the "Custom Run" button, and add more frameworks by writing their names (space separated) in the "Compilation Flags" field.
+By default, the script will link against a set of default frameworks. However, you can click the "Custom Run" button, and add more frameworks by writing their names (space separated) in the "Compilation Flags" field.


### PR DESCRIPTION
@MarkVillacampa, I've corrected a typographical error in the documentation of the [motion-coderunner](https://github.com/MarkVillacampa/motion-coderunner) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
